### PR TITLE
Add 1.20.1 questline

### DIFF
--- a/config/ftbquests/snbt/dangerous_start.snbt
+++ b/config/ftbquests/snbt/dangerous_start.snbt
@@ -1,0 +1,87 @@
+{
+  chapters: [
+    {
+      id: 0,
+      title: "Dangerous Start",
+      quests: [
+        {
+          id: 1,
+          title: "Bread for the Journey",
+          description: "The smell of warm bread fills the camp. Before venturing forth, gather 128 loafs for the group.",
+          icon: "minecraft:bread",
+          tasks: [
+            {id: 11, type: "item", item: "minecraft:bread", count: 128}
+          ],
+          rewards: [
+            {id: 12, type: "item", item: "minecraft:cooked_beef", count: 16}
+          ]
+        },
+        {
+          id: 2,
+          title: "First Blood",
+          description: "A sinister Rare Lighter from the Creeping Woods has been spotted. Slay it to prove your strength.",
+          icon: "creepingwoods:rare_lighter_spawn_egg",
+          tasks: [
+            {id: 21, type: "kill", entity: "creepingwoods:rare_lighter", count: 1}
+          ],
+          rewards: [
+            {id: 22, type: "xp", xp: 100}
+          ],
+          dependencies: [1]
+        },
+        {
+          id: 3,
+          title: "Distress Call",
+          description: "When four adventurers are online, a random one is whisked 1,000 blocks away and slowed. Friends must reach them in time!",
+          icon: "minecraft:ender_pearl",
+          tasks: [
+            {id: 31, type: "custom", id_name: "kubejs:rescueevent"}
+          ],
+          rewards: [
+            {id: 32, type: "item", item: "minecraft:golden_carrot", count: 3}
+          ],
+          dependencies: [2]
+        },
+        {
+          id: 4,
+          title: "Iron Reserves",
+          description: "Even simple iron is precious in these wilds. Gather 32 ingots for tools and defense.",
+          icon: "minecraft:iron_ingot",
+          tasks: [
+            {id: 41, type: "item", item: "minecraft:iron_ingot", count: 32}
+          ],
+          rewards: [
+            {id: 42, type: "item", item: "minecraft:shield", count: 1}
+          ],
+          dependencies: [3]
+        },
+        {
+          id: 5,
+          title: "Silence the Spirit Guide",
+          description: "Born from chaos, the Spirit Guide whispers doom. Defeat it before its influence spreads.",
+          icon: "born_in_chaos_v1:spirit_guide_spawn_egg",
+          tasks: [
+            {id: 51, type: "kill", entity: "born_in_chaos_v1:spirit_guide", count: 1}
+          ],
+          rewards: [
+            {id: 52, type: "item", item: "minecraft:emerald", count: 5}
+          ],
+          dependencies: [4]
+        },
+        {
+          id: 6,
+          title: "Laviathan's Bane",
+          description: "A colossal Laviathan roams the seas. Defeat this beast and secure safe waters for all.",
+          icon: "alexsmobs:spawn_egg_laviathan",
+          tasks: [
+            {id: 61, type: "kill", entity: "alexsmobs:laviathan", count: 1}
+          ],
+          rewards: [
+            {id: 62, type: "item", item: "minecraft:heart_of_the_sea", count: 1}
+          ],
+          dependencies: [5]
+        }
+      ]
+    }
+  ]
+}

--- a/kubejs/server_scripts/teleport_rescue.js
+++ b/kubejs/server_scripts/teleport_rescue.js
@@ -1,0 +1,66 @@
+ServerEvents.commandRegistry(event => {
+  const {commands: Commands} = event;
+  event.register('rescueevent').requires(s => s.hasPermission(2)).executes(ctx => {
+    const server = ctx.source.server;
+    const players = server.players;
+    if (players.length < 4) {
+      ctx.source.sendFailure(Text.of('Need at least 4 players online.'));
+      return 0;
+    }
+    const target = players[Math.floor(Math.random() * players.length)];
+    const world = target.level;
+    const pos = target.position();
+    const tx = pos.x + (Math.random() * 2000 - 1000);
+    const tz = pos.z + (Math.random() * 2000 - 1000);
+    const y = world.getHeight(Heightmap.Types.MOTION_BLOCKING, tx, tz) + 1;
+    target.teleportTo(tx, y, tz);
+    target.addEffect('minecraft:slowness', 36000, 9);
+    server.tell(Text.of(target.name.string + ' has been lost! Rescue them!'));
+
+    const interval = 20; // check every second
+    const limit = 36000; // 1.5 Minecraft days
+    const mobs = [
+      'born_in_chaos_v1:decrepit_skeleton',
+      'creepingwoods:rare_lighter',
+      'undead_revamp2:bomber',
+      'sons_of_sins:prowler',
+      'alexsmobs:grizzly_bear'
+    ];
+    let time = 0;
+    let spawned = false;
+    const checkRescue = () => {
+      time += interval;
+      let rescued = false;
+      for (const p of server.players) {
+        if (p != target && p.distanceTo(target) <= 5) {
+          if (!spawned) {
+            const mob = mobs[Math.floor(Math.random() * mobs.length)];
+            server.runCommandSilent(
+              `execute in ${world.dimension()} run summon ${mob} ${target.x} ${target.y} ${target.z}`
+            );
+            spawned = true;
+          }
+          rescued = true;
+          break;
+        }
+      }
+
+      if (rescued) {
+        target.removeEffect('minecraft:slowness');
+        server.tell(Text.of(target.name.string + ' was saved!'));
+      } else if (time >= limit) {
+        target.inventory.clear();
+        target.kill();
+        const tx2 = tx + (Math.random() * 2000 - 1000);
+        const tz2 = tz + (Math.random() * 2000 - 1000);
+        const y2 = world.getHeight(Heightmap.Types.MOTION_BLOCKING, tx2, tz2) + 1;
+        target.teleportTo(tx2, y2, tz2);
+      } else {
+        server.scheduleInTicks(interval, checkRescue);
+      }
+    };
+
+    server.scheduleInTicks(interval, checkRescue);
+    return 1;
+  });
+});


### PR DESCRIPTION
## Summary
- trim quest line to six quests in `dangerous_start.snbt`
- keep rescue event logic in `teleport_rescue.js`
- allow 1.5 in-game days to rescue the player and spawn a moderate mob when help arrives

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687bd9547c8c832986abe2bbca6f397c